### PR TITLE
Add support for packed attestation format (surrogate attestation type)

### DIFF
--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -80,7 +80,7 @@ pub(crate) fn verify_packed_attestation(
     client_data_hash: &Vec<u8>,
     counter: u32,
 ) -> Result<AttestationType, WebauthnError> {
-    //Verify that attStmt is valid CBOR conforming to the syntax defined above
+    // Verify that attStmt is valid CBOR conforming to the syntax defined above
     // and perform CBOR decoding on it to extract the contained fields
     let att_stmt_map = att_stmt
         .as_object()

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -83,14 +83,12 @@ pub(crate) fn verify_packed_attestation(
         (None, None) => {
             let credential_public_key = crypto::COSEKey::try_from(&acd.credential_pk)?;
 
-            //TODO: Validate that alg matches the algorithm of the credentialPublicKey in authenticatorData.
+            //Validate that alg matches the algorithm of the credentialPublicKey in authenticatorData
             let alg = att_stmt_map
                 .get(&serde_cbor::ObjectKey::String("alg".to_string()))
-                .ok_or(WebauthnError::AttestationStatementSigMissing)?;
-            if alg.as_i64() != None {
-                //algorithm -7 ("ES256"),
-                println!("{:?} != {:?}", alg, credential_public_key.key);
-                //return Err(WebauthnError::AttestationStatementSigInvalid);
+                .ok_or(WebauthnError::AttestationStatementAlgMismatch)?;
+            if alg.as_i64() != Some(i64::from(&credential_public_key.type_)) {
+                return Err(WebauthnError::AttestationStatementAlgMismatch);
             }
 
             // Verify that sig is a valid signature over the concatenation

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -8,9 +8,6 @@ use std::convert::TryFrom;
 use crate::crypto;
 use crate::error::WebauthnError;
 use crate::proto::{AttestedCredentialData, Credential};
-use std::collections::BTreeMap;
-use serde_cbor::{ObjectKey, Value};
-
 
 #[derive(Debug)]
 pub(crate) enum AttestationFormat {
@@ -76,10 +73,13 @@ pub(crate) fn verify_packed_attestation(
         .ok_or(WebauthnError::AttestationStatementMapInvalid)?;
 
     let x5c_key = &serde_cbor::ObjectKey::String("x5c".to_string());
-    let ecdaaKeyId_key = &serde_cbor::ObjectKey::String("ecdaaKeyId".to_string());
-    match (att_stmt_map.get(x5c_key), att_stmt_map.get(ecdaaKeyId_key)) {
-        (Some(x5c), _) => Err(WebauthnError::AttestationNotSupported),
-        (None, Some(ecdaaKeyId))=> Err(WebauthnError::AttestationNotSupported),
+    let ecdaa_key_id_key = &serde_cbor::ObjectKey::String("ecdaaKeyId".to_string());
+    match (
+        att_stmt_map.get(x5c_key),
+        att_stmt_map.get(ecdaa_key_id_key),
+    ) {
+        (Some(_x5c), _) => Err(WebauthnError::AttestationNotSupported),
+        (None, Some(_ecdaa_key_id)) => Err(WebauthnError::AttestationNotSupported),
         (None, None) => {
             let credential_public_key = crypto::COSEKey::try_from(&acd.credential_pk)?;
 
@@ -93,31 +93,24 @@ pub(crate) fn verify_packed_attestation(
                 //return Err(WebauthnError::AttestationStatementSigInvalid);
             }
 
-            //Verify that sig is a valid signature over the concatenation of authenticatorData and clientDataHash using the credential public key with alg.
+            // Verify that sig is a valid signature over the concatenation
+            // of authenticatorData and clientDataHash using the credential public key with alg.
             let verification_data: Vec<u8> = auth_data_bytes
                 .iter()
                 .chain(client_data_hash.iter())
                 .map(|b| *b)
                 .collect();
-
-            let sig_value = att_stmt_map
+            let sig = att_stmt_map
                 .get(&serde_cbor::ObjectKey::String("sig".to_string()))
-                .ok_or(WebauthnError::AttestationStatementSigMissing)?;
-
-            let sig = sig_value
+                .ok_or(WebauthnError::AttestationStatementSigMissing)?
                 .as_bytes()
                 .ok_or(WebauthnError::AttestationStatementSigMissing)?;
-
-            // Verify the sig using verificationData and certificate public key per [SEC1].
-            let verified =
-                credential_public_key.verify_signature(&sig, &verification_data)?;
-
+            let verified = credential_public_key.verify_signature(&sig, &verification_data)?;
             if !verified {
                 return Err(WebauthnError::AttestationStatementSigInvalid);
             }
 
             let credential = Credential::new(acd, credential_public_key, counter);
-
             Ok(AttestationType::Self_(credential))
         }
     }

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -5,10 +5,10 @@
 
 use std::convert::TryFrom;
 
+use crate::attestation::AttestationType::Self_;
 use crate::crypto;
 use crate::error::WebauthnError;
 use crate::proto::{AttestedCredentialData, Credential};
-use crate::attestation::AttestationType::Self_;
 
 #[derive(Debug)]
 pub(crate) enum AttestationFormat {
@@ -72,11 +72,9 @@ pub(crate) fn verify_packed_attestation(
         .as_object()
         .ok_or(WebauthnError::AttestationStatementMapInvalid)?;
 
-    match att_stmt_map
-        .get(&serde_cbor::ObjectKey::String("x5c".to_string())) {
+    match att_stmt_map.get(&serde_cbor::ObjectKey::String("x5c".to_string())) {
         None => {
-            match att_stmt_map
-                .get(&serde_cbor::ObjectKey::String("ecdaaKeyId".to_string())) {
+            match att_stmt_map.get(&serde_cbor::ObjectKey::String("ecdaaKeyId".to_string())) {
                 None => {
                     //Surrogate
 
@@ -89,7 +87,7 @@ pub(crate) fn verify_packed_attestation(
                     if alg.as_i64() != None {
                         //algorithm -7 ("ES256"),
                         println!("{:?} != {:?}", alg, credential_public_key.key);
-//                        return Err(WebauthnError::AttestationStatementSigInvalid);
+                        //return Err(WebauthnError::AttestationStatementSigInvalid);
                     }
 
                     //Verify that sig is a valid signature over the concatenation of authenticatorData and clientDataHash using the credential public key with alg.
@@ -108,7 +106,8 @@ pub(crate) fn verify_packed_attestation(
                         .ok_or(WebauthnError::AttestationStatementSigMissing)?;
 
                     // Verify the sig using verificationData and certificate public key per [SEC1].
-                    let verified = credential_public_key.verify_signature(&sig, &verification_data)?;
+                    let verified =
+                        credential_public_key.verify_signature(&sig, &verification_data)?;
 
                     if !verified {
                         return Err(WebauthnError::AttestationStatementSigInvalid);

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -5,7 +5,6 @@
 
 use std::convert::TryFrom;
 
-use crate::attestation::AttestationType::Self_;
 use crate::crypto;
 use crate::error::WebauthnError;
 use crate::proto::{AttestedCredentialData, Credential};
@@ -115,7 +114,7 @@ pub(crate) fn verify_packed_attestation(
 
                     let credential = Credential::new(acd, credential_public_key, counter);
 
-                    Ok(Self_(credential))
+                    Ok(AttestationType::Self_(credential))
                 }
                 Some(_) => {
                     //If ecdaaKeyId is present, then the attestation type is ECDAA

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -44,7 +44,8 @@ pub enum AttestationType {
     /// The credential is authenticated by a signing X509 Certificate
     /// from a vendor or provider.
     Basic(Credential, crypto::X509PublicKey),
-    /// Unimplemented
+    /// The credential is authenticated using surrogate basic attestation
+    /// it uses the credential private key to create the attestation signature
     Self_(Credential),
     /// Unimplemented
     AttCa,

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -57,8 +57,6 @@ pub enum AttestationType {
 }
 
 // https://w3c.github.io/webauthn/#sctn-packed-attestation
-// https://medium.com/@herrjemand/verifying-fido2-packed-attestation-a067a9b2facd
-//https://gist.github.com/herrjemand/dbeb2c2b76362052e5268224660b6fbc#file-verify-packed-webauthn-js
 pub(crate) fn verify_packed_attestation(
     att_stmt: &serde_cbor::Value,
     acd: &AttestedCredentialData,

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -59,8 +59,7 @@ pub enum AttestationType {
     Uncertain(Credential),
 }
 
-// first Verification procedure if self attestation is in use.
-// Validate that alg matches the algorithm of the credentialPublicKey in authenticatorData.
+// Check that alg from att_stmt_map matches alg_from_auhenticator_data
 fn is_matching_agorithm(
     att_stmt_map: &BTreeMap<ObjectKey, Value>,
     alg_from_auhenticator_data: &COSEContentType,
@@ -72,6 +71,7 @@ fn is_matching_agorithm(
         .unwrap_or(false)
 }
 
+// Perform the Verification procedure for 8.2. Packed Attestation Statement Format
 // https://w3c.github.io/webauthn/#sctn-packed-attestation
 pub(crate) fn verify_packed_attestation(
     att_stmt: &serde_cbor::Value,
@@ -80,8 +80,7 @@ pub(crate) fn verify_packed_attestation(
     client_data_hash: &Vec<u8>,
     counter: u32,
 ) -> Result<AttestationType, WebauthnError> {
-    // Verify that attStmt is valid CBOR conforming to the syntax defined above
-    // and perform CBOR decoding on it to extract the contained fields
+    // 1. Verify that attStmt is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the contained fields
     let att_stmt_map = att_stmt
         .as_object()
         .ok_or(WebauthnError::AttestationStatementMapInvalid)?;
@@ -92,18 +91,26 @@ pub(crate) fn verify_packed_attestation(
         att_stmt_map.get(x5c_key),
         att_stmt_map.get(ecdaa_key_id_key),
     ) {
-        (Some(_x5c), _) => Err(WebauthnError::AttestationNotSupported),
-        (None, Some(_ecdaa_key_id)) => Err(WebauthnError::AttestationNotSupported),
+        (Some(_x5c), _) => {
+            // 2. If x5c is present, this indicates that the attestation type is not ECDAA.
+            // TODO: Perform the appropriate verification procedure
+            Err(WebauthnError::AttestationNotSupported)
+        }
+        (None, Some(_ecdaa_key_id)) => {
+            // 3. If ecdaaKeyId is present, then the attestation type is ECDAA.
+            // TODO: Perform the the verification procedure for ECDAA
+            Err(WebauthnError::AttestationNotSupported)
+        }
         (None, None) => {
-            // If neither x5c nor ecdaaKeyId is present, self attestation is in use.
+            // 4. If neither x5c nor ecdaaKeyId is present, self attestation is in use.
             let credential_public_key = crypto::COSEKey::try_from(&acd.credential_pk)?;
 
+            // 4.a. Validate that alg matches the algorithm of the credentialPublicKey in authenticatorData.
             if !is_matching_agorithm(att_stmt_map, &credential_public_key.type_) {
                 return Err(WebauthnError::AttestationStatementAlgMismatch);
             }
 
-            // Verify that sig is a valid signature over the concatenation
-            // of authenticatorData and clientDataHash using the credential public key with alg.
+            // 4.b. Verify that sig is a valid signature over the concatenation of authenticatorData and clientDataHash using the credential public key with alg.
             let verification_data: Vec<u8> = auth_data_bytes
                 .iter()
                 .chain(client_data_hash.iter())
@@ -118,6 +125,7 @@ pub(crate) fn verify_packed_attestation(
                 return Err(WebauthnError::AttestationStatementSigInvalid);
             }
 
+            // 4.c. If successful, return implementation-specific values representing attestation type Self and an empty attestation trust path.
             Ok(AttestationType::Self_(Credential::new(
                 acd,
                 credential_public_key,

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,9 @@ pub enum WebauthnError {
     AttestationStatementX5CMissing,
     /// The attestation statement x5c (trust root) is not valid.
     AttestationStatementX5CInvalid,
+    /// The attestation statement alg does not match algorithm of the
+    /// credentialPublicKey in authenticatorData
+    AttestationStatementAlgMismatch,
     /// The attestation trust could not be established.
     AttestationTrustFailure,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -782,9 +782,9 @@ pub trait WebauthnConfig {
     /// 16 above, the Relying Party SHOULD fail the registration ceremony.
     ///
     /// The default implementation of this method rejects None and Uncertain attestation, and
-    /// will "blindly trust" the other types as valid. If you have strict security requirements
-    /// we strongly recommend you implement this function, and we may in the future provide a
-    /// stronger default trust system.
+    /// will "blindly trust" self attestation and the other types as valid.
+    /// If you have strict security requirements we strongly recommend you implement this function,
+    /// and we may in the future provide a stronger default replying party policy.
     fn policy_verify_trust(&self, at: AttestationType) -> Result<Credential, ()> {
         match at {
             AttestationType::Basic(credential, _ca) => Ok(credential),
@@ -898,7 +898,7 @@ mod tests {
     }
 
     #[test]
-    fn test_registration_packed() {
+    fn test_registration_packed_attestation() {
         let wan_c = WebauthnEphemeralConfig::new(
             "localhost:8443/auth",
             "https://localhost:8443",
@@ -914,6 +914,7 @@ mod tests {
             .unwrap(),
         );
 
+        // Generated using Touch ID via Chrome
         let rsp = r#"{"id":"ATk_7QKbi_ntSdp16LXeU6RDf9YnRLIDTCqEjJFzc6rKBhbqoSYccxNa","rawId":"ATk/7QKbi/ntSdp16LXeU6RDf9YnRLIDTCqEjJFzc6rKBhbqoSYccxNa","response":{"attestationObject":"o2NmbXRmcGFja2VkZ2F0dFN0bXSiY2FsZyZjc2lnWEcwRQIgLXPjBtVEhBH3KdUDFFk3LAd9EtHogllIf48vjX4wgfECIQCXOymmfg12FPMXEdwpSjjtmrvki4K8y0uYxqWN5Bw6DGhhdXRoRGF0YViuSZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2NFXaqejq3OAAI1vMYKZIsLJfHwVQMAKgE5P+0Cm4v57Unadei13lOkQ3/WJ0SyA0wqhIyRc3OqygYW6qEmHHMTWqUBAgMmIAEhWCDNRS/Gw52ow5PNrC9OdFTFNudDmZO6Y3wmM9N8e0tJICJYIC09iIH5/RrT5tbS0PIw3srdAxYDMGao7yWgu0JFIEzT","clientDataJSON":"eyJjaGFsbGVuZ2UiOiJsUDZtV05BdEctX1Z2MTVpTTdsYl9YUmtkV012VlEtbFR5S3dadU9nMVZvIiwiZXh0cmFfa2V5c19tYXlfYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCIsIm9yaWdpbiI6Imh0dHBzOi8vbG9jYWxob3N0Ojg0NDMiLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0="},"type":"public-key"}
         "#;
         let rsp_d: RegisterPublicKeyCredential = serde_json::from_str(rsp).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -784,7 +784,7 @@ pub trait WebauthnConfig {
     /// The default implementation of this method rejects None and Uncertain attestation, and
     /// will "blindly trust" self attestation and the other types as valid.
     /// If you have strict security requirements we strongly recommend you implement this function,
-    /// and we may in the future provide a stronger default replying party policy.
+    /// and we may in the future provide a stronger default relying party policy.
     fn policy_verify_trust(&self, at: AttestationType) -> Result<Credential, ()> {
         match at {
             AttestationType::Basic(credential, _ca) => Ok(credential),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -914,7 +914,8 @@ mod tests {
             .unwrap(),
         );
 
-        // Generated using Touch ID via Chrome
+        // Example generated using navigator.credentials.create on Chrome Version 77.0.3865.120
+        // using Touch ID on MacBook running MacOS 10.15
         let rsp = r#"{"id":"ATk_7QKbi_ntSdp16LXeU6RDf9YnRLIDTCqEjJFzc6rKBhbqoSYccxNa","rawId":"ATk/7QKbi/ntSdp16LXeU6RDf9YnRLIDTCqEjJFzc6rKBhbqoSYccxNa","response":{"attestationObject":"o2NmbXRmcGFja2VkZ2F0dFN0bXSiY2FsZyZjc2lnWEcwRQIgLXPjBtVEhBH3KdUDFFk3LAd9EtHogllIf48vjX4wgfECIQCXOymmfg12FPMXEdwpSjjtmrvki4K8y0uYxqWN5Bw6DGhhdXRoRGF0YViuSZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2NFXaqejq3OAAI1vMYKZIsLJfHwVQMAKgE5P+0Cm4v57Unadei13lOkQ3/WJ0SyA0wqhIyRc3OqygYW6qEmHHMTWqUBAgMmIAEhWCDNRS/Gw52ow5PNrC9OdFTFNudDmZO6Y3wmM9N8e0tJICJYIC09iIH5/RrT5tbS0PIw3srdAxYDMGao7yWgu0JFIEzT","clientDataJSON":"eyJjaGFsbGVuZ2UiOiJsUDZtV05BdEctX1Z2MTVpTTdsYl9YUmtkV012VlEtbFR5S3dadU9nMVZvIiwiZXh0cmFfa2V5c19tYXlfYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCIsIm9yaWdpbiI6Imh0dHBzOi8vbG9jYWxob3N0Ojg0NDMiLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0="},"type":"public-key"}
         "#;
         let rsp_d: RegisterPublicKeyCredential = serde_json::from_str(rsp).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,9 @@ pub mod proto;
 use rand::prelude::*;
 use std::convert::TryFrom;
 
-use crate::attestation::{verify_fidou2f_attestation, verify_packed_attestation, AttestationFormat, AttestationType};
+use crate::attestation::{
+    verify_fidou2f_attestation, verify_packed_attestation, AttestationFormat, AttestationType,
+};
 use crate::constants::{AUTHENTICATOR_TIMEOUT, CHALLENGE_SIZE_BYTES};
 use crate::crypto::{compute_sha256, COSEContentType};
 use crate::error::WebauthnError;
@@ -341,17 +343,13 @@ impl<T> Webauthn<T> {
                 // &rp_hash,
                 data.attestation_object.authData.counter,
             ),
-            AttestationFormat::Packed => {
-                verify_packed_attestation(
-                    &data.attestation_object.attStmt,
-                    acd,
-                    data
-                        .attestation_object
-                        .authDataBytes,
-                    &client_data_json_hash,
-                    data.attestation_object.authData.counter,
-                )
-            }
+            AttestationFormat::Packed => verify_packed_attestation(
+                &data.attestation_object.attStmt,
+                acd,
+                data.attestation_object.authDataBytes,
+                &client_data_json_hash,
+                data.attestation_object.authData.counter,
+            ),
             _ => {
                 // No other types are currently implemented
                 Err(WebauthnError::AttestationNotSupported)
@@ -913,7 +911,7 @@ mod tests {
                 "lP6mWNAtG+/Vv15iM7lb/XRkdWMvVQ+lTyKwZuOg1Vo=",
                 base64::Base64Mode::Standard,
             )
-                .unwrap(),
+            .unwrap(),
         );
 
         let rsp = r#"{"id":"ATk_7QKbi_ntSdp16LXeU6RDf9YnRLIDTCqEjJFzc6rKBhbqoSYccxNa","rawId":"ATk/7QKbi/ntSdp16LXeU6RDf9YnRLIDTCqEjJFzc6rKBhbqoSYccxNa","response":{"attestationObject":"o2NmbXRmcGFja2VkZ2F0dFN0bXSiY2FsZyZjc2lnWEcwRQIgLXPjBtVEhBH3KdUDFFk3LAd9EtHogllIf48vjX4wgfECIQCXOymmfg12FPMXEdwpSjjtmrvki4K8y0uYxqWN5Bw6DGhhdXRoRGF0YViuSZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2NFXaqejq3OAAI1vMYKZIsLJfHwVQMAKgE5P+0Cm4v57Unadei13lOkQ3/WJ0SyA0wqhIyRc3OqygYW6qEmHHMTWqUBAgMmIAEhWCDNRS/Gw52ow5PNrC9OdFTFNudDmZO6Y3wmM9N8e0tJICJYIC09iIH5/RrT5tbS0PIw3srdAxYDMGao7yWgu0JFIEzT","clientDataJSON":"eyJjaGFsbGVuZ2UiOiJsUDZtV05BdEctX1Z2MTVpTTdsYl9YUmtkV012VlEtbFR5S3dadU9nMVZvIiwiZXh0cmFfa2V5c19tYXlfYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCIsIm9yaWdpbiI6Imh0dHBzOi8vbG9jYWxob3N0Ojg0NDMiLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0="},"type":"public-key"}


### PR DESCRIPTION
This PR adds support for surrogate attestation type for packed attestation format and solve https://github.com/Firstyear/webauthn-rs/issues/17.

After that change, I was able to use the example web server to register and authenticate with touchID using Chrome (Version 77.0.3865.120).

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] documentation has been updated with relevant examples (if relevant)