### PR TITLE
W3C Conformance Fixes and Other Minor Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0"
 # We could consider replacing this with openssl rand.
 openssl = "0.10"
 rand = "0.6"
+thiserror = "1.0"
 
 [dev-dependencies]
 askama = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["authentication", "web-programming"]
 license = "MPL-2.0"
 
 [dependencies]
-base64 = "0.2"
+base64 = "0.12"
 lru = "0.1"
 log = "0.4"
 nom = "4.2"

--- a/examples/actix/main.rs
+++ b/examples/actix/main.rs
@@ -229,7 +229,7 @@ fn main() {
     let domain = opt.rp_id.clone();
 
     // Generate TLS certs as needed.
-    let ssl_params = generate_dyn_ssl_params(domain.as_str());
+    // let ssl_params = generate_dyn_ssl_params(domain.as_str());
 
     let wan_c = WebauthnEphemeralConfig::new(
         opt.rp_name.as_str(),
@@ -277,7 +277,9 @@ fn main() {
             )
     });
     server
-        .bind_openssl(opt.bind.as_str(), ssl_params)
+        // .bind_openssl(opt.bind.as_str(), ssl_params)
+        // .unwrap()
+        .bind("localhost:8080")
         .unwrap()
         .run();
 

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -11,6 +11,7 @@ use crate::error::WebauthnError;
 use crate::proto::{AttestedCredentialData, Credential};
 use serde_cbor::{ObjectKey, Value};
 use std::collections::BTreeMap;
+use log::debug;
 
 #[derive(Debug)]
 pub(crate) enum AttestationFormat {
@@ -97,7 +98,7 @@ pub(crate) fn verify_packed_attestation(
         att_stmt_map.get(ecdaa_key_id_key),
     ) {
         (Some(x5c), _) => {
-            println!("x5c");
+            debug!("x5c");
             let credential_public_key = crypto::COSEKey::try_from(&acd.credential_pk)?;
             // 2. If x5c is present, this indicates that the attestation type is not ECDAA.
 
@@ -177,7 +178,7 @@ pub(crate) fn verify_packed_attestation(
         (None, Some(_ecdaa_key_id)) => {
             // 3. If ecdaaKeyId is present, then the attestation type is ECDAA.
             // TODO: Perform the the verification procedure for ECDAA
-            println!("_ecdaa_key_id");
+            debug!("_ecdaa_key_id");
             Err(WebauthnError::AttestationNotSupported)
         }
         (None, None) => {
@@ -308,7 +309,7 @@ pub(crate) fn verify_fidou2f_attestation(
     let verified = cerificate_public_key.verify_signature(&sig, &verification_data)?;
 
     if !verified {
-        println!("signature verification failed!");
+        log::error!("signature verification failed!");
         return Err(WebauthnError::AttestationStatementSigInvalid);
     }
 

--- a/src/base64_data.rs
+++ b/src/base64_data.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::{Visitor, Error, Unexpected};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Base64UrlSafeData(pub Vec<u8>);
+
+impl AsRef<[u8]> for Base64UrlSafeData {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+struct Base64UrlSafeDataVisitor;
+
+impl<'de> Visitor<'de> for Base64UrlSafeDataVisitor {
+    type Value = Base64UrlSafeData;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a base64 url encoded string")
+    }
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where
+        E: Error, {
+
+        match base64::decode_config(v, base64::URL_SAFE_NO_PAD) {
+            Ok(data) => Ok(Base64UrlSafeData(data)),
+            Err(_) => {
+                Err(serde::de::Error::invalid_value(Unexpected::Str(v), &self))
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Base64UrlSafeData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error> where
+        D: Deserializer<'de> {
+        deserializer.deserialize_str(Base64UrlSafeDataVisitor)
+    }
+}
+
+impl Serialize for Base64UrlSafeData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        let encoded = base64::encode_config(&self, base64::URL_SAFE_NO_PAD);
+        serializer.serialize_str(&encoded)
+    }
+}

--- a/src/base64_data.rs
+++ b/src/base64_data.rs
@@ -5,8 +5,19 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Base64UrlSafeData(pub Vec<u8>);
 
+impl Into<Vec<u8>> for Base64UrlSafeData {
+    fn into(self) -> Vec<u8> {
+        self.0
+    }
+}
 impl AsRef<[u8]> for Base64UrlSafeData {
     fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsRef<Vec<u8>> for Base64UrlSafeData {
+    fn as_ref(&self) -> &Vec<u8> {
         &self.0
     }
 }

--- a/src/base64_data.rs
+++ b/src/base64_data.rs
@@ -10,14 +10,15 @@ impl Into<Vec<u8>> for Base64UrlSafeData {
         self.0
     }
 }
-impl AsRef<[u8]> for Base64UrlSafeData {
-    fn as_ref(&self) -> &[u8] {
+
+impl AsRef<Vec<u8>> for Base64UrlSafeData {
+    fn as_ref(&self) -> &Vec<u8> {
         &self.0
     }
 }
 
-impl AsRef<Vec<u8>> for Base64UrlSafeData {
-    fn as_ref(&self) -> &Vec<u8> {
+impl AsRef<[u8]> for Base64UrlSafeData {
+    fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Possible errors that may occur during Webauthn Operation processing
 
-use base64::Base64Error as b64DecodeError;
+use base64::DecodeError as b64DecodeError;
 use openssl::error::ErrorStack as OpenSSLErrorStack;
 use serde_cbor::error::Error as CBORError;
 use serde_json::error::Error as JSONError;

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,108 +7,140 @@ use serde_json::error::Error as JSONError;
 // use nom::Err as NOMError;
 
 /// Possible errors that may occur during Webauthn Operation proessing.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum WebauthnError {
-    /// The JSON from the client did not indicate webauthn.<method> correctly.
+    #[error("The JSON from the client did not indicate webauthn.<method> correctly")]
     InvalidClientDataType,
-    /// The client response challenge differs from the latest challenge issued to
-    /// the userId.
+
+    #[error("The client response challenge differs from the latest challenge issued to the userId")]
     MismatchedChallenge,
-    /// There are no challenges associated to the UserId.
+
+    #[error("There are no challenges associated to the UserId")]
     ChallengeNotFound,
-    /// The clients relying party origin does not match our servers information
+
+    #[error("The clients relying party origin does not match our servers information")]
     InvalidRPOrigin,
-    /// The clients relying party id hash does not match the hash of our
-    /// relying party id.
+
+    #[error("The clients relying party id hash does not match the hash of our relying party id")]
     InvalidRPIDHash,
-    /// The user present bit is not set, and required.
+
+    #[error("The user present bit is not set, and required")]
     UserNotPresent,
-    /// The user verified bit is not set, and required by policy.
+
+    #[error("The user verified bit is not set, and required by policy")]
     UserNotVerified,
-    /// The user verified even through discouragement.
+
+    #[error("The user verified even through discouragement")]
     UserVerifiedWhenDiscouraged,
-    /// The extensions are unknown to this server.
+
+    #[error("The extensions are unknown to this server")]
     InvalidExtensions,
-    /// The required attestation data is not present in the response.
+
+    #[error("The required attestation data is not present in the response")]
     MissingAttestationCredentialData,
-    /// The attestation format requested is not able to be processed
-    /// by this server - please report an issue to add the attestation format.
+
+    #[error("The attestation format requested is not able to be processed by this server - please report an issue to add the attestation format")]
     AttestationNotSupported,
 
-    /// A failure occured in persisting the Challenge data.
+    #[error("A failure occured in persisting the Challenge data")]
     ChallengePersistenceError,
 
-    /// The attestation statement map is not valid.
+    #[error("The attestation statement map is not valid")]
     AttestationStatementMapInvalid,
-    /// The attestation statement signature is not present.
+
+    #[error("The attestation statement signature is not present")]
     AttestationStatementSigMissing,
-    /// The attestation statement signature is not valid.
+
+    #[error("The attestation statement signature is not valid")]
     AttestationStatementSigInvalid,
-    /// The attestation statement x5c (trust root) is not present.
+
+    #[error("The attestation statement x5c (trust root) is not present")]
     AttestationStatementX5CMissing,
-    /// The attestation statement x5c (trust root) is not valid.
+
+    #[error("The attestation statement x5c (trust root) is not valid")]
     AttestationStatementX5CInvalid,
-    /// The attestation statement alg does not match algorithm of the
-    /// credentialPublicKey in authenticatorData
+
+    #[error("The attestation statement alg does not match algorithm of the credentialPublicKey in authenticatorData")]
     AttestationStatementAlgMismatch,
-    /// The attestation trust could not be established.
+
+    #[error("The attestation trust could not be established")]
     AttestationTrustFailure,
-    /// The attestation Certificates OID 1.3.6.1.4.1.45724.1.1.4 aaguid does not
-    /// match the aaguid of the token.
+
+    #[error("The attestation Certificates OID 1.3.6.1.4.1.45724.1.1.4 aaguid does not match the aaguid of the token")]
     AttestationCertificateAAGUIDMismatch,
-    /// The requirements of https://w3c.github.io/webauthn/#sctn-packed-attestation-cert-requirements
-    /// are not met by this attestation certificate.
+
+    #[error("The requirements of https://w3c.github.io/webauthn/#sctn-packed-attestation-cert-requirements are not met by this attestation certificate")]
     AttestationCertificateRequirementsNotMet,
 
-    /// The X5C trust root is not a valid algorithm for signing.
+    #[error("The X5C trust root is not a valid algorithm for signing")]
     CertificatePublicKeyInvalid,
 
-    /// A base64 parser failure has occured
-    ParseBase64Failure(b64DecodeError),
-    /// A CBOR parser failure has occured
-    ParseCBORFailure(CBORError),
-    /// A JSON parser failure has occured
-    ParseJSONFailure(JSONError),
-    /// A NOM parser failure has occured.
+
+    #[error("A base64 parser failure has occurred")]
+    ParseBase64Failure(#[from] b64DecodeError),
+
+    #[error("A CBOR parser failure has occurred")]
+    ParseCBORFailure(#[from] CBORError),
+
+    #[error("A JSON parser failure has occurred")]
+    ParseJSONFailure(#[from] JSONError),
+
+
+    #[error("A NOM parser failure has occurred")]
     ParseNOMFailure,
-    /// In parsing the attestation object, there was insufficent data
+
+    #[error("In parsing the attestation object, there was insufficient data")]
     ParseInsufficentBytesAvailable,
-    /// An openSSL Error has occured
-    OpenSSLError(OpenSSLErrorStack),
-    /// The requested OpenSSL curve is not supported by OpenSSL.
+
+    #[error("An openSSL Error has occured")]
+    OpenSSLError(#[from] OpenSSLErrorStack),
+
+    #[error("The requested OpenSSL curve is not supported by OpenSSL")]
     OpenSSLErrorNoCurveName,
 
-    /// The COSEKey contains invalid CBOR which can not be processed.
+    #[error("The COSEKey contains invalid CBOR which can not be processed")]
     COSEKeyInvalidCBORValue,
-    /// The COSEKey type is not supported by this implementation.
+
+    #[error("The COSEKey type is not supported by this implementation")]
     COSEKeyInvalidType,
-    /// The COSEKey contains invalid X/Y coordinate data.
+
+    #[error("The COSEKey contains invalid X/Y coordinate data")]
     COSEKeyECDSAXYInvalid,
-    /// The COSEKey uses a curve that is not supported by this implementation.
+
+    #[error("The COSEKey uses a curve that is not supported by this implementation")]
     COSEKeyECDSAInvalidCurve,
-    /// The COSEKey contains invalid cryptographic algorithm request.
+
+    #[error("The COSEKey contains invalid cryptographic algorithm request")]
     COSEKeyECDSAContentType,
 
-    /// The credential exist check failed
+    #[error("The credential exist check failed")]
     CredentialExistCheckError,
-    /// The credential already exists
+
+    #[error("The credential already exists")]
     CredentialAlreadyExists,
-    /// The credential was not able to be persisted
+
+    #[error("The credential was not able to be persisted")]
     CredentialPersistenceError,
-    /// The credential was not able to be retrieved
+
+    #[error("The credential was not able to be retrieved")]
     CredentialRetrievalError,
-    /// The credential requested could not be found.
+
+    #[error("The credential requested could not be found")]
     CredentialNotFound,
-    /// The credential may have be compromised and should be inspected.
+
+    #[error("The credential may have be compromised and should be inspected")]
     CredentialPossibleCompromise,
-    /// The credential counter could not be updated.
+
+    #[error("The credential counter could not be updated")]
     CredentialCounterUpdateFailure,
-    /// The provided call back failed to allow reporting the credential failure.
+
+    #[error("The provided call back failed to allow reporting the credential failure")]
     CredentialCompromiseReportFailure,
 
-    /// The trust path could not be established.
+    #[error("The trust path could not be established")]
     TrustFailure,
 
-    /// Authentication has failed.
+    #[error("Authentication has failed")]
     AuthenticationFailure,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,6 @@ impl<T> Webauthn<T> {
         // authenticatorData, and signature respectively.
         // Let JSONtext be the result of running UTF-8 decode on the value of cData.
         let data = AuthenticatorAssertionResponse::try_from(&rsp.response)?;
-        // println!("data: {:?}", data);
 
         let c = &data.client_data;
 
@@ -668,23 +667,21 @@ impl<T> Webauthn<T> {
             //      verify that credential.response.userHandle is present, and that the user identified
             //      by this value is the owner of credentialSource.
             //
-            // TODO: Not done yet
+            // TODO: support webauthn in user-less mode -- i.e. the authenticator tells us the userhandle
+            // TODO: and we must see if this userhandle is allowed entry
 
             // Using credential’s id attribute (or the corresponding rawId, if base64url encoding is
             // inappropriate for your use case), look up the corresponding credential public key.
-
-            let cred_opt: Option<Credential> = creds.iter().fold(None, |acc, c| {
-                if acc.is_none() && c.cred_id == rsp.raw_id.0 {
-                    Some((*c).clone())
-                } else {
-                    acc
+            let mut found_cred:Option<Credential> = None;
+            for cred in creds {
+                if cred.cred_id == rsp.raw_id.0 {
+                    found_cred = Some(cred);
+                    break
                 }
-            });
+            }
 
-            cred_opt.ok_or(WebauthnError::CredentialNotFound)?
+            found_cred.ok_or(WebauthnError::CredentialNotFound)?
         };
-
-        // let policy = self.config.policy_user_verification(&username);
 
         let counter = self.verify_credential_internal(rsp, policy, chal.into(), &cred)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,12 +496,6 @@ impl<T> Webauthn<T> {
 
         // Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID expected by the Relying Party.
         if data.authenticator_data.rp_id_hash != self.rp_id_hash {
-            /*
-            println!("rp_id_hash from authenitcatorData does not match our rp_id_hash");
-            let a: String = base64::encode(&data.authenticatorData.rp_id_hash);
-            let b: String = base64::encode(&self.rp_id_hash);
-            println!("{:?} != {:?}", a, b);
-            */
             return Err(WebauthnError::InvalidRPIDHash);
         }
 
@@ -597,8 +591,6 @@ impl<T> Webauthn<T> {
         let policy = policy.unwrap_or(UserVerificationPolicy::Preferred);
 
         // Get the user's existing creds if any.
-        // println!("login_challenge: {:?}", uc);
-
         let ac = creds
             .iter()
             .map(|cred| AllowCredentials {
@@ -662,10 +654,6 @@ impl<T> Webauthn<T> {
         // that would be equivalent to what was allowed.
         // println!("rsp: {:?}", rsp);
 
-        let raw_id = base64::decode_config(&rsp.raw_id, base64::URL_SAFE_NO_PAD)
-            .or(base64::decode_config(&rsp.raw_id, base64::URL_SAFE_NO_PAD))
-            .map_err(|e| WebauthnError::ParseBase64Failure(e))?;
-
         let cred = {
             // Identify the user being authenticated and verify that this user is the owner of the public
             // key credential source credentialSource identified by credential.id:
@@ -686,7 +674,7 @@ impl<T> Webauthn<T> {
             // inappropriate for your use case), look up the corresponding credential public key.
 
             let cred_opt: Option<Credential> = creds.iter().fold(None, |acc, c| {
-                if acc.is_none() && c.cred_id == raw_id {
+                if acc.is_none() && c.cred_id == rsp.raw_id.0 {
                     Some((*c).clone())
                 } else {
                     acc

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -84,6 +84,7 @@ impl PartialEq<Credential> for Credential {
 /// the only interaction - we only verify a user is present, but we don't have extra details
 /// to the legitimacy of that user.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum UserVerificationPolicy {
     /// Require User Verification bit to be set, and fail the registration or authentication
     /// if false. If the authenticator is not able to perform verification, it may not be
@@ -98,21 +99,12 @@ pub enum UserVerificationPolicy {
     Discouraged,
 }
 
-impl ToString for UserVerificationPolicy {
-    fn to_string(&self) -> String {
-        match self {
-            UserVerificationPolicy::Required => "required".to_string(),
-            UserVerificationPolicy::Preferred => "preferred".to_string(),
-            UserVerificationPolicy::Discouraged => "discouraged".to_string(),
-        }
-    }
-}
-
 // These are the primary communication structures you will need to handle.
 pub(crate) type JSONExtensions = BTreeMap<String, String>;
 
 /// Relying Party Entity
 #[derive(Debug, Serialize)]
+#[serde(rename_all="camelCase")]
 pub struct RelyingParty {
     pub(crate) name: String,
     pub(crate) id: String,
@@ -120,7 +112,7 @@ pub struct RelyingParty {
 
 /// User Entity
 #[derive(Debug, Serialize)]
-#[serde(rename = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct User {
     pub(crate) id: Base64UrlSafeData,
     pub(crate) name: String,
@@ -217,8 +209,9 @@ pub enum AuthenticatorTransport {
 /// to inspect or alter the content of the struct - you should serialise it
 /// and transmit it to the client only.
 #[derive(Debug, Serialize)]
+#[serde(rename_all="camelCase")]
 pub struct CreationChallengeResponse {
-    pub(crate) publicKey: PublicKeyCredentialCreationOptions,
+    pub(crate) public_key: PublicKeyCredentialCreationOptions,
 }
 
 
@@ -229,7 +222,7 @@ pub(crate) struct PublicKeyCredentialRequestOptions {
     timeout: u32,
     rp_id: String,
     allow_credentials: Vec<AllowCredentials>,
-    user_verification: String,
+    user_verification: UserVerificationPolicy,
     extensions: Option<JSONExtensions>,
 }
 
@@ -256,7 +249,7 @@ impl RequestChallengeResponse {
                 timeout,
                 rp_id: relaying_party,
                 allow_credentials,
-                user_verification: user_verification_policy.to_string(),
+                user_verification: user_verification_policy,
                 extensions: None,
             },
         }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -12,13 +12,14 @@ use crate::base64_data::Base64UrlSafeData;
 
 use serde::{Serialize, Deserialize};
 
-/// Representation of a UserId. This is currently a type alias to "String".
+/// Representation of a UserId
 pub type UserId = Vec<u8>;
 
 /// Representation of a device counter
 pub type Counter = u32;
 
 /// Representation of an AAGUID
+/// https://www.w3.org/TR/webauthn/#aaguid
 pub type Aaguid = Vec<u8>;
 
 /// A challenge issued by the server. This contains a set of random bytes

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -143,10 +143,20 @@ pub struct PublicKeyCredentialCreationOptions {
     pub(crate) user: User,
     pub(crate) challenge: Base64UrlSafeData,
     pub(crate) pub_key_cred_params: Vec<PubKeyCredParams>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) timeout: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) attestation: Option<AttestationConveyancePreference>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) exclude_credentials: Option<Vec<PublicKeyCredentialDescriptor>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) authenticator_selection: Option<AuthenticatorSelectionCriteria>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) extensions: Option<JSONExtensions>,
 }
 
@@ -154,9 +164,14 @@ pub struct PublicKeyCredentialCreationOptions {
 #[derive(Debug, Serialize)]
 #[serde(rename_all="camelCase")]
 pub struct AuthenticatorSelectionCriteria {
-    authenticator_attachment: Option<String>,
-    require_resident_key: Option<bool>,
-    user_verification: Option<String>
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) authenticator_attachment: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) require_resident_key: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) user_verification: Option<UserVerificationPolicy>
 }
 
 

--- a/static/js/webauthn.js
+++ b/static/js/webauthn.js
@@ -129,7 +129,7 @@ function login() {
           pk.response.authenticatorData = toBase64(credentials.response.authenticatorData);
           pk.response.clientDataJSON = toBase64(credentials.response.clientDataJSON);
           pk.response.signature = toBase64(credentials.response.signature);
-          pk.response.userHandle = credentials.response.userHandle;
+          pk.response.userHandle = toBase64(credentials.response.userHandle);
           pk.type = credentials.type;
 
           return fetch(LOGIN_URL + username, {
@@ -161,10 +161,21 @@ function login() {
 
 // HOLY WHAT THIS ONLY WORKS WITH A SINGLE CHARACTER WTF
 
+
 function toBase64(data) {
-  return btoa(String.fromCharCode.apply(null, new Uint8Array(data)))
+    let b64val = btoa(String.fromCharCode.apply(null, new Uint8Array(data)));
+    return b64val.replace(/\//g, '_').replace(/\+/g, '-').replace(/=/g, '');
 }
 
 function fromBase64(data) {
-  return Uint8Array.from(atob(data), c => c.charCodeAt(0))
+    let fixed = data.replace(/_/g, '/').replace(/-/g, '+');
+    while (fixed.length % 4 !== 0) {
+        fixed += "=";
+    }
+    return toArray(atob(fixed));
 }
+
+function toArray(str) {
+    return Uint8Array.from(str, c => c.charCodeAt(0));
+}
+


### PR DESCRIPTION
A few minor improvements:
- allow library user customization on register via arguments 
- use snake case and serde rename
- use a custom type to represent base64 url safe, no pad encoded bytes (implement ser/de traits on it)
- expose certain properties to library users (i.e. pub(crate) -> pub).
- WebAuthnError conforms to Error trait now via `this error`.


- [ ] cargo fmt has been run
- [x ] cargo test has been run and passes
- [x ] documentation has been updated with relevant examples (if relevant)
